### PR TITLE
Update GitHub Actions to account for upstream IREE changes.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,7 @@ jobs:
       run : |
         git \
             -c submodule."third_party/llvm-project".update=none \
+            -c submodule."third_party/torch-mlir".update=none \
             submodule update --init --recursive
     - name: Build sample
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,10 @@ jobs:
       run: |
         sudo apt update
         sudo apt install cmake clang ninja-build
+    - name: Setting up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
     - name: Install IREE compiler
       run: |
         python -m pip install iree-compiler

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ $ git submodule add https://github.com/openxla/iree.git third_party/iree/
 $ git submodule update --init --recursive
 ```
 
-For a faster checkout the LLVM dependency can be dropped as this template is
-only compiling the runtime (only bother if optimizing build bots):
+For a faster checkout the LLVM and torch-mlir dependencies can be dropped as
+this template is only compiling the runtime (only bother if optimizing build
+bots):
 
 ```sh
 $ git \
     -c submodule."third_party/llvm-project".update=none \
+    -c submodule."third_party/torch-mlir".update=none \
     submodule update --init --recursive
 ```
 

--- a/hello_world.c
+++ b/hello_world.c
@@ -170,8 +170,8 @@ static iree_status_t iree_runtime_demo_perform_mul(
           (iree_hal_buffer_params_t){
               // Where to allocate (host or device):
               .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-              // Access to allow to this memory (this is .rodata so READ only):
-              .access = IREE_HAL_MEMORY_ACCESS_READ,
+              // Access to allow to this memory:
+              .access = IREE_HAL_MEMORY_ACCESS_ALL,
               // Intended usage of the buffer (transfers, dispatches, etc):
               .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
           },
@@ -202,7 +202,7 @@ static iree_status_t iree_runtime_demo_perform_mul(
           IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
           (iree_hal_buffer_params_t){
               .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-              .access = IREE_HAL_MEMORY_ACCESS_READ,
+              .access = IREE_HAL_MEMORY_ACCESS_ALL,
               .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
           },
           iree_make_const_byte_span(rhs_data, sizeof(rhs_data)), &rhs);


### PR DESCRIPTION
* Skip updating torch-mlir submodule for faster checkouts
* Set up Python prior to installing packages (runners used Python 3.8, need Python 3.9+)
* Fix API usage