### PR TITLE
Add build matrix to CI.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build_linux:
     name: Build and Test (Linux)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,7 +74,10 @@ jobs:
         export CC=${{ matrix.cc_compiler }}
         export CXX=${{ matrix.cxx_compiler }}
 
-    - name: Configure MSVC (Windows)
+    - name: Install ninja (Windows)
+      run: choco install ninja --yes
+
+    - name: Test versions (Windows)
       if: contains(matrix.os, 'windows')
       run: |
         which cmake
@@ -89,9 +92,6 @@ jobs:
     # - name: Configure clang (Windows)
     #   if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
     #   uses: egor-tensin/setup-clang@v1
-
-    - name: Install ninja (Windows)
-      uses: seanmiddleditch/gha-setup-ninja@master
 
     - name: Configure clang (Windows)
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,12 +43,12 @@ jobs:
           #   cc_compiler: gcc
           #   cxx_compiler: g++
 
-          - name: windows-2019 - msvc
-            os: windows-2019
-            compiler: msvc
-          - name: windows-2022 - msvc
-            os: windows-2022
-            compiler: msvc
+          # - name: windows-2019 - msvc
+          #   os: windows-2019
+          #   compiler: msvc
+          # - name: windows-2022 - msvc
+          #   os: windows-2022
+          #   compiler: msvc
 
           - name: windows-2019 - clang
             os: windows-2019
@@ -85,6 +85,7 @@ jobs:
     - name: Configure clang (Windows)
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
       run: |
+        ls "C:\Program Files\LLVM\bin"
         export CC="C:\Program Files\LLVM\bin\clang.exe"
         export CXX="C:\Program Files\LLVM\bin\clang++.exe"
 
@@ -115,6 +116,8 @@ jobs:
 
     - name: Build sample
       run: |
+        export CC="C:\Program Files\LLVM\bin\clang.exe"
+        export CXX="C:\Program Files\LLVM\bin\clang++.exe"
         cmake -B build/ -G Ninja
         cmake --build build/ --target hello_world
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,14 +19,33 @@ concurrency:
 
 jobs:
   build_and_test:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
-          - os: windows-2019
-          - os: windows-2022
+          - name: ubuntu-20.04 - clang
+            os: ubuntu-20.04
+            cc_compiler: clang
+            cxx_compiler: clang++
+          - name: ubuntu-22.04 - clang
+            os: ubuntu-22.04
+            cc_compiler: clang
+            cxx_compiler: clang++
+
+          - name: ubuntu-20.04 - gcc
+            os: ubuntu-20.04
+            cc_compiler: gcc
+            cxx_compiler: g++
+          - name: ubuntu-22.04 - gcc
+            os: ubuntu-22.04
+            cc_compiler: gcc
+            cxx_compiler: g++
+
+          - name: windows-2019 - msvc
+            os: windows-2019
+          - name: windows-2022 - msvc
+            os: windows-2022
 
     steps:
 
@@ -39,8 +58,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install cmake clang ninja-build
-        export CC=/usr/bin/clang
-        export CXX=/usr/bin/clang++
+        export CC=${{ matrix.cc_compiler }}
+        export CXX=${{ matrix.cxx_compiler }}
 
     - name: Configure MSVC (Windows)
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,28 +25,37 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubuntu-20.04 - clang
-            os: ubuntu-20.04
-            cc_compiler: clang
-            cxx_compiler: clang++
-          - name: ubuntu-22.04 - clang
-            os: ubuntu-22.04
-            cc_compiler: clang
-            cxx_compiler: clang++
+          # - name: ubuntu-20.04 - clang
+          #   os: ubuntu-20.04
+          #   cc_compiler: clang
+          #   cxx_compiler: clang++
+          # - name: ubuntu-22.04 - clang
+          #   os: ubuntu-22.04
+          #   cc_compiler: clang
+          #   cxx_compiler: clang++
 
-          - name: ubuntu-20.04 - gcc
-            os: ubuntu-20.04
-            cc_compiler: gcc
-            cxx_compiler: g++
-          - name: ubuntu-22.04 - gcc
-            os: ubuntu-22.04
-            cc_compiler: gcc
-            cxx_compiler: g++
+          # - name: ubuntu-20.04 - gcc
+          #   os: ubuntu-20.04
+          #   cc_compiler: gcc
+          #   cxx_compiler: g++
+          # - name: ubuntu-22.04 - gcc
+          #   os: ubuntu-22.04
+          #   cc_compiler: gcc
+          #   cxx_compiler: g++
 
           - name: windows-2019 - msvc
             os: windows-2019
+            compiler: msvc
           - name: windows-2022 - msvc
             os: windows-2022
+            compiler: msvc
+
+          - name: windows-2019 - clang
+            os: windows-2019
+            compiler: clang
+          - name: windows-2022 - clang
+            os: windows-2022
+            compiler: clang
     defaults:
       run:
         shell: bash
@@ -66,8 +75,14 @@ jobs:
         export CXX=${{ matrix.cxx_compiler }}
 
     - name: Configure MSVC (Windows)
-      if: contains(matrix.os, 'windows')
+      if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'msvc')
       uses: ilammy/msvc-dev-cmd@v1.12.1
+
+    - name: Configure clang (Windows)
+      if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: clang64
 
     ###########################################################################
     # General setup

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,9 +78,15 @@ jobs:
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'msvc')
       uses: ilammy/msvc-dev-cmd@v1.12.1
 
+    # - name: Configure clang (Windows)
+    #   if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
+    #   uses: egor-tensin/setup-clang@v1
+
     - name: Configure clang (Windows)
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
-      uses: egor-tensin/setup-clang@v1
+      run: |
+        export CC="C:\Program Files\LLVM\bin\clang.exe"
+        export CXX="C:\Program Files\LLVM\bin\clang++.exe"
 
     ###########################################################################
     # General setup

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,37 +25,44 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - name: ubuntu-20.04 - clang
-          #   os: ubuntu-20.04
-          #   cc_compiler: clang
-          #   cxx_compiler: clang++
-          # - name: ubuntu-22.04 - clang
-          #   os: ubuntu-22.04
-          #   cc_compiler: clang
-          #   cxx_compiler: clang++
+          - name: ubuntu-20.04 - clang
+            os: ubuntu-20.04
+            cc_compiler: clang
+            cxx_compiler: clang++
+          - name: ubuntu-22.04 - clang
+            os: ubuntu-22.04
+            cc_compiler: clang
+            cxx_compiler: clang++
 
-          # - name: ubuntu-20.04 - gcc
-          #   os: ubuntu-20.04
-          #   cc_compiler: gcc
-          #   cxx_compiler: g++
-          # - name: ubuntu-22.04 - gcc
-          #   os: ubuntu-22.04
-          #   cc_compiler: gcc
-          #   cxx_compiler: g++
+          - name: ubuntu-20.04 - gcc
+            os: ubuntu-20.04
+            cc_compiler: gcc
+            cxx_compiler: g++
+          - name: ubuntu-22.04 - gcc
+            os: ubuntu-22.04
+            cc_compiler: gcc
+            cxx_compiler: g++
 
-          # - name: windows-2019 - msvc
-          #   os: windows-2019
-          #   compiler: msvc
+          - name: windows-2019 - msvc
+            os: windows-2019
+            compiler: msvc
           - name: windows-2022 - msvc
             os: windows-2022
             compiler: msvc
 
-          # - name: windows-2019 - clang
-          #   os: windows-2019
-          #   compiler: clang
+          - name: windows-2019 - clang
+            os: windows-2019
+            compiler: clang
           - name: windows-2022 - clang
             os: windows-2022
             compiler: clang
+
+          - name: windows-2019 - gcc
+            os: windows-2019
+            compiler: gcc
+          - name: windows-2022 - gcc
+            os: windows-2022
+            compiler: gcc
     defaults:
       run:
         shell: bash
@@ -84,6 +91,12 @@ jobs:
         choco install ninja --yes
         echo "CC='C:\Program Files\LLVM\bin\clang.exe'" >> $GITHUB_ENV
         echo "CXX='C:\Program Files\LLVM\bin\clang++.exe'" >> $GITHUB_ENV
+
+    - name: Configure GCC (Windows)
+      if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'gcc')
+      uses: egor-tensin/setup-mingw@v2
+      with:
+        version: 12.2.0
 
     ###########################################################################
     # General setup

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,25 +54,30 @@ jobs:
       run: |
         ./build/hello_world local-sync build/simple_mul.vmfb
 
-  # TODO(scotttodd): fold into build matrix with build_linux
-  # TODO(scotttodd): test multiple compilers
-  build_windows:
-    name: Build and Test (Windows)
-    runs-on: windows-2022
-    defaults:
-      run:
-        shell: bash
+  # TODO(scotttodd): fold into build matrix with build_linux?
+  windows:
+    name: ${{ matrix.os }} - ${{ matrix.vs-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-2019
+            vsversion: 2019
+          - os: windows-2019
+            vsversion: 2022
+          - os: windows-2022
+            vsversion: 2019
+          - os: windows-2022
+            vsversion: 2022
     steps:
-    # - name: Install dependencies
-    #   run: |
-    #     sudo apt update
-    #     sudo apt install cmake clang ninja-build
     - name: Setting up Python
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
     - name: "Configuring MSVC"
       uses: ilammy/msvc-dev-cmd@v1.12.1
+      with:
+        vsversion: ${{ matrix.vsversion }}
     - name: Install IREE compiler
       run: |
         python -m pip install iree-compiler

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,8 +82,8 @@ jobs:
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
       run: |
         choco install ninja --yes
-        export CC="C:\Program Files\LLVM\bin\clang.exe"
-        export CXX="C:\Program Files\LLVM\bin\clang++.exe"
+        echo "CC='C:\Program Files\LLVM\bin\clang.exe'" >> $GITHUB_ENV
+        echo "CXX='C:\Program Files\LLVM\bin\clang++.exe'" >> $GITHUB_ENV
 
     ###########################################################################
     # General setup

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,19 +50,22 @@ jobs:
             os: windows-2022
             compiler: msvc
 
-          - name: windows-2019 - clang
-            os: windows-2019
-            compiler: clang
-          - name: windows-2022 - clang
-            os: windows-2022
-            compiler: clang
+          # As of IREE commit 44c93468, Windows only reliably supports MSVC and
+          # clang-cl. clang and gcc builds could be added with a few changes.
 
-          - name: windows-2019 - gcc
-            os: windows-2019
-            compiler: gcc
-          - name: windows-2022 - gcc
-            os: windows-2022
-            compiler: gcc
+          # - name: windows-2019 - clang
+          #   os: windows-2019
+          #   compiler: clang
+          # - name: windows-2022 - clang
+          #   os: windows-2022
+          #   compiler: clang
+
+          # - name: windows-2019 - gcc
+          #   os: windows-2019
+          #   compiler: gcc
+          # - name: windows-2022 - gcc
+          #   os: windows-2022
+          #   compiler: gcc
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,6 +82,9 @@ jobs:
     #   if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
     #   uses: egor-tensin/setup-clang@v1
 
+    - name: Install ninja (Windows)
+      uses: seanmiddleditch/gha-setup-ninja@master
+
     - name: Configure clang (Windows)
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: ubuntu-20.04 - clang
@@ -46,6 +47,9 @@ jobs:
             os: windows-2019
           - name: windows-2022 - msvc
             os: windows-2022
+    defaults:
+      run:
+        shell: bash
 
     steps:
 
@@ -79,7 +83,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Initialize submodules
-      shell: bash
       run : |
         git \
             -c submodule."third_party/llvm-project".update=none \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,8 +14,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Build and Test
+  build_linux:
+    name: Build and Test (Linux)
     runs-on: ubuntu-20.04
     steps:
     - name: Install dependencies
@@ -26,6 +26,52 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Install IREE compiler
+      run: |
+        python -m pip install iree-compiler
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize submodules
+      run : |
+        git \
+            -c submodule."third_party/llvm-project".update=none \
+            -c submodule."third_party/torch-mlir".update=none \
+            submodule update --init --recursive
+    - name: Build sample
+      run: |
+        cmake -B build/ -G Ninja \
+          -DCMAKE_C_COMPILER=clang-10 \
+          -DCMAKE_CXX_COMPILER=clang++-10
+        cmake --build build/ --target hello_world
+    - name: Compile sample module
+      run: |
+        iree-compile \
+          --iree-hal-target-backends=llvm-cpu \
+          simple_mul.mlir \
+          -o build/simple_mul.vmfb
+    - name: Test execution
+      run: |
+        ./build/hello_world local-sync build/simple_mul.vmfb
+
+  # TODO(scotttodd): fold into build matrix with build_linux
+  # TODO(scotttodd): test multiple compilers
+  build_windows:
+    name: Build and Test (Windows)
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: bash
+    steps:
+    # - name: Install dependencies
+    #   run: |
+    #     sudo apt update
+    #     sudo apt install cmake clang ninja-build
+    - name: Setting up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: "Configuring MSVC"
+      uses: ilammy/msvc-dev-cmd@v1.12.1
     - name: Install IREE compiler
       run: |
         python -m pip install iree-compiler

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,6 +63,9 @@ jobs:
         include:
           - os: windows-2019
           - os: windows-2022
+    defaults:
+      run:
+        shell: bash
     steps:
     - name: Setting up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,6 +35,7 @@ jobs:
       run : |
         git \
             -c submodule."third_party/llvm-project".update=none \
+            -c submodule."third_party/stablehlo".update=none \
             -c submodule."third_party/torch-mlir".update=none \
             submodule update --init --recursive
     - name: Build sample
@@ -81,13 +82,12 @@ jobs:
       run : |
         git \
             -c submodule."third_party/llvm-project".update=none \
+            -c submodule."third_party/stablehlo".update=none \
             -c submodule."third_party/torch-mlir".update=none \
             submodule update --init --recursive
     - name: Build sample
       run: |
-        cmake -B build/ -G Ninja \
-          -DCMAKE_C_COMPILER=clang-10 \
-          -DCMAKE_CXX_COMPILER=clang++-10
+        cmake -B build/ -G Ninja
         cmake --build build/ --target hello_world
     - name: Compile sample module
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,87 +18,72 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_linux:
-    name: Build and Test (Linux)
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install cmake clang ninja-build
-    - name: Setting up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
-    - name: Install IREE compiler
-      run: |
-        python -m pip install iree-compiler
-    - name: Checkout repository
-      uses: actions/checkout@v2
-    - name: Initialize submodules
-      run : |
-        git \
-            -c submodule."third_party/llvm-project".update=none \
-            -c submodule."third_party/stablehlo".update=none \
-            -c submodule."third_party/torch-mlir".update=none \
-            submodule update --init --recursive
-    - name: Build sample
-      run: |
-        cmake -B build/ -G Ninja \
-          -DCMAKE_C_COMPILER=clang-10 \
-          -DCMAKE_CXX_COMPILER=clang++-10
-        cmake --build build/ --target hello_world
-    - name: Compile sample module
-      run: |
-        iree-compile \
-          --iree-hal-target-backends=llvm-cpu \
-          simple_mul.mlir \
-          -o build/simple_mul.vmfb
-    - name: Test execution
-      run: |
-        ./build/hello_world local-sync build/simple_mul.vmfb
-
-  # TODO(scotttodd): fold into build matrix with build_linux?
-  windows:
+  build_and_test:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
+          - os: ubuntu-20.04
           - os: windows-2019
           - os: windows-2022
-    defaults:
-      run:
-        shell: bash
+
     steps:
-    - name: Setting up Python
+
+    ###########################################################################
+    # OS specific setup
+    ###########################################################################
+
+    - name: Install dependencies (Linux)
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo apt update
+        sudo apt install cmake clang ninja-build
+        export CC=/usr/bin/clang
+        export CXX=/usr/bin/clang++
+
+    - name: Configure MSVC (Windows)
+      if: contains(matrix.os, 'windows')
+      uses: ilammy/msvc-dev-cmd@v1.12.1
+
+    ###########################################################################
+    # General setup
+    ###########################################################################
+
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: "3.11"
-    - name: "Configuring MSVC"
-      uses: ilammy/msvc-dev-cmd@v1.12.1
     - name: Install IREE compiler
       run: |
         python -m pip install iree-compiler
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Initialize submodules
+      shell: bash
       run : |
         git \
             -c submodule."third_party/llvm-project".update=none \
             -c submodule."third_party/stablehlo".update=none \
             -c submodule."third_party/torch-mlir".update=none \
             submodule update --init --recursive
+
+    ###########################################################################
+    # Build and test
+    ###########################################################################
+
     - name: Build sample
       run: |
         cmake -B build/ -G Ninja
         cmake --build build/ --target hello_world
+
     - name: Compile sample module
       run: |
         iree-compile \
           --iree-hal-target-backends=llvm-cpu \
           simple_mul.mlir \
           -o build/simple_mul.vmfb
+
     - name: Test execution
       run: |
         ./build/hello_world local-sync build/simple_mul.vmfb

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setting up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install IREE compiler
       run: |
         python -m pip install iree-compiler
@@ -69,7 +69,7 @@ jobs:
     - name: Setting up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: "Configuring MSVC"
       uses: ilammy/msvc-dev-cmd@v1.12.1
     - name: Install IREE compiler

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -112,8 +112,6 @@ jobs:
 
     - name: Build sample
       run: |
-        export CC="C:\Program Files\LLVM\bin\clang.exe"
-        export CXX="C:\Program Files\LLVM\bin\clang++.exe"
         cmake -B build/ -G Ninja
         cmake --build build/ --target hello_world
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,29 +74,14 @@ jobs:
         export CC=${{ matrix.cc_compiler }}
         export CXX=${{ matrix.cxx_compiler }}
 
-    - name: Install ninja (Windows)
-      run: choco install ninja --yes
-
-    - name: Test versions (Windows)
-      if: contains(matrix.os, 'windows')
-      run: |
-        which cmake
-        cmake --version
-        which ninja
-        ninja --version
-
     - name: Configure MSVC (Windows)
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'msvc')
       uses: ilammy/msvc-dev-cmd@v1.12.1
 
-    # - name: Configure clang (Windows)
-    #   if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
-    #   uses: egor-tensin/setup-clang@v1
-
     - name: Configure clang (Windows)
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
       run: |
-        ls "C:\Program Files\LLVM\bin"
+        choco install ninja --yes
         export CC="C:\Program Files\LLVM\bin\clang.exe"
         export CXX="C:\Program Files\LLVM\bin\clang++.exe"
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,13 +46,13 @@ jobs:
           # - name: windows-2019 - msvc
           #   os: windows-2019
           #   compiler: msvc
-          # - name: windows-2022 - msvc
-          #   os: windows-2022
-          #   compiler: msvc
+          - name: windows-2022 - msvc
+            os: windows-2022
+            compiler: msvc
 
-          - name: windows-2019 - clang
-            os: windows-2019
-            compiler: clang
+          # - name: windows-2019 - clang
+          #   os: windows-2019
+          #   compiler: clang
           - name: windows-2022 - clang
             os: windows-2022
             compiler: clang
@@ -73,6 +73,14 @@ jobs:
         sudo apt install cmake clang ninja-build
         export CC=${{ matrix.cc_compiler }}
         export CXX=${{ matrix.cxx_compiler }}
+
+    - name: Configure MSVC (Windows)
+      if: contains(matrix.os, 'windows')
+      run: |
+        which cmake
+        cmake --version
+        which ninja
+        ninja --version
 
     - name: Configure MSVC (Windows)
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'msvc')

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,9 +80,7 @@ jobs:
 
     - name: Configure clang (Windows)
       if: contains(matrix.os, 'windows') && contains(matrix.compiler, 'clang')
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: clang64
+      uses: egor-tensin/setup-clang@v1
 
     ###########################################################################
     # General setup

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,19 +56,13 @@ jobs:
 
   # TODO(scotttodd): fold into build matrix with build_linux?
   windows:
-    name: ${{ matrix.os }} - ${{ matrix.vs-version }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - os: windows-2019
-            vsversion: 2019
-          - os: windows-2019
-            vsversion: 2022
           - os: windows-2022
-            vsversion: 2019
-          - os: windows-2022
-            vsversion: 2022
     steps:
     - name: Setting up Python
       uses: actions/setup-python@v4
@@ -76,8 +70,6 @@ jobs:
         python-version: "3.11"
     - name: "Configuring MSVC"
       uses: ilammy/msvc-dev-cmd@v1.12.1
-      with:
-        vsversion: ${{ matrix.vsversion }}
     - name: Install IREE compiler
       run: |
         python -m pip install iree-compiler

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IREE Runtime Hello World with CMake
 
-![Build with Latest IREE Release](https://github.com/iree-org/iree-template-runtime-cmake/workflows/IREE%20Runtime%20Template/badge.svg)
+[![Build with Latest IREE Release](https://github.com/iree-org/iree-template-runtime-cmake/actions/workflows/build-and-test.yml/badge.svg?query=branch%3Amain+event%3Apush)](https://github.com/iree-org/iree-template-runtime-cmake/actions/workflows/build-and-test.yml?query=branch%3Amain+event%3Apush)
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ $ git submodule add https://github.com/openxla/iree.git third_party/iree/
 $ git submodule update --init --recursive
 ```
 
-For a faster checkout the LLVM and torch-mlir dependencies can be dropped as
-this template is only compiling the runtime (only bother if optimizing build
-bots):
+For a faster checkout some compiler-only dependencies can be dropped as this
+template is only compiling the runtime (only bother if optimizing build bots):
 
 ```sh
 $ git \
     -c submodule."third_party/llvm-project".update=none \
+    -c submodule."third_party/stablehlo".update=none \
     -c submodule."third_party/torch-mlir".update=none \
     submodule update --init --recursive
 ```


### PR DESCRIPTION
This has configurations for Windows + [clang, gcc], but I was only able to compile successfully on Windows + MSVC. Logs with the full matrix enabled are here: https://github.com/iree-org/iree-template-runtime-cmake/actions/runs/6670553422.

We have a similar build matrix upstream in IREE itself, but this is much simpler and easier to reference. We can point developers at this when they want to debug their own build environments.