### PR TITLE
Bump IREE to f2746b46.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,7 +111,7 @@ jobs:
         python-version: "3.11"
     - name: Install IREE compiler
       run: |
-        python -m pip install iree-compiler
+        python -m pip install iree-compiler==20240410.859
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Initialize submodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "third_party/iree"]
 	path = third_party/iree
-	url = https://github.com/openxla/iree.git
+	url = https://github.com/iree-org/iree.git

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If working in an existing repository then add the submodule and ensure it has
 its submodules initialized:
 
 ```sh
-$ git submodule add https://github.com/openxla/iree.git third_party/iree/
+$ git submodule add https://github.com/iree-org/iree.git third_party/iree/
 $ git submodule update --init --recursive
 ```
 
@@ -31,6 +31,7 @@ template is only compiling the runtime (only bother if optimizing build bots):
 $ git \
     -c submodule."third_party/llvm-project".update=none \
     -c submodule."third_party/stablehlo".update=none \
+    -c submodule."third_party/torch-mlir".update=none \
     -c submodule."third_party/torch-mlir".update=none \
     submodule update --init --recursive
 ```
@@ -52,11 +53,11 @@ $ cmake --build build/ --target hello_world
 
 ### Compiling the Sample Module
 
-This sample assumes that the latest IREE compiler release is installed and used
-to compile the module. For many users upgrading their `iree-compiler` install
-when they bump their submodule should be sufficient to ensure the compiler and
-runtime are compatible. In the future the compiler and runtime will have more
-support for version shifting.
+This sample assumes that a compatible IREE compiler release is installed and
+used to compile the module. For many users upgrading their `iree-compiler`
+install when they bump their submodule should be sufficient to ensure the
+compiler and runtime are compatible. In the future the compiler and runtime
+will have more support for version shifting.
 
 The sample currently assumes a CPU HAL driver and only produces a VMFB
 supporting that. Additional compiler options can be used to change the target
@@ -67,7 +68,7 @@ can be accomplished with the `--iree-llvm-target-triple=` flag specifying the
 CPU architecture.
 
 ```sh
-$ python -m pip install iree-compiler --upgrade --user
+$ python -m pip install iree-compiler==20240410.859 --upgrade --user
 $ iree-compile \
     --iree-hal-target-backends=llvm-cpu \
     --iree-llvmcpu-target-triple=x86_64 \

--- a/simple_mul.mlir
+++ b/simple_mul.mlir
@@ -2,7 +2,7 @@
 // framework (JAX, PyTorch, TFLite, etc).
 //
 // Refer to the documentation for frontend-specific instructions:
-//   https://openxla.github.io/iree/guides/ml-frameworks/
+//   https://iree.dev/guides/ml-frameworks/
 
 // Simple elementwise multiply:
 //   %result = %lhs * %rhs


### PR DESCRIPTION
https://github.com/iree-org/iree/commit/f2746b464fb056ddadef4315654d59f727e4c9b0

This includes
* A migration back from the `openxla` GitHub organization to `iree-org`
* Pinning to the latest stable release of the `iree-compiler` package on PyPI: https://pypi.org/project/iree-compiler/#history
* Rolling forward past the HAL module version change from https://github.com/iree-org/iree/commit/80e70ca460ba07e57df7da56b9e8302c3e358e9f