### PR TITLE
Bump IREE to candidate-20240724.964.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,7 +111,7 @@ jobs:
         python-version: "3.11"
     - name: Install IREE compiler
       run: |
-        python -m pip install iree-compiler==20240410.859
+        python -m pip install iree-compiler==20240724.964
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Initialize submodules


### PR DESCRIPTION
This is the latest stable release: https://github.com/iree-org/iree/releases/tag/candidate-20240724.964