### PR TITLE
Bump IREE to candidate-20240828.999.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -130,7 +130,7 @@ jobs:
           python-version: "3.11"
       - name: Install IREE compiler
         run: |
-          python -m pip install iree-compiler==20240724.964
+          python -m pip install iree-compiler==20240828.999
       - name: Checkout repository
         uses: actions/checkout@v4.1.7
       - name: Initialize submodules

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ the IREE project and/or pass the configuration to the CMake configure command.
 The sample currently compiles in the synchronous CPU HAL driver (`local-sync`).
 
 ```sh
-$ cmake -B build/ -GNinja .
+$ cmake -B build/ -G Ninja .
 $ cmake --build build/ --target hello_world
 ```
 
@@ -67,7 +67,7 @@ can be accomplished with the `--iree-llvm-target-triple=` flag specifying the
 CPU architecture.
 
 ```sh
-$ python -m pip install iree-compiler==20240410.859 --upgrade --user
+$ python -m pip install iree-compiler==20240828.999 --upgrade --user
 $ iree-compile \
     --iree-hal-target-backends=llvm-cpu \
     --iree-llvmcpu-target-triple=x86_64 \


### PR DESCRIPTION
This is the latest stable release: https://github.com/iree-org/iree/releases/tag/candidate-20240828.999 . See also https://pypi.org/project/iree-compiler/#history.

Progress on https://github.com/iree-org/iree/issues/18380.